### PR TITLE
add buildSrc settings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion Dependencies.sdkVersion
     defaultConfig {
         applicationId "org.t_robop.kochab"
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion Dependencies.minSdkVersion
+        targetSdkVersion Dependencies.targetVersion
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -24,11 +24,11 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.core:core-ktx:1.0.1'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    implementation Dependencies.kotlinLib
+    implementation Dependencies.appCompat
+    implementation Dependencies.androidxCore
+    implementation Dependencies.androidxConstraint
+    testImplementation Dependencies.junit
+    androidTestImplementation Dependencies.testRunner
+    androidTestImplementation Dependencies.espressoCore
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    `kotlin-dsl`
+}
+repositories {
+    jcenter()
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,0 +1,22 @@
+object Dependencies {
+    object Version {
+        val kotlin = "1.2.71"
+        val appcompat = "1.0.2"
+        val androidx = "1.0.1"
+        val constraint = "1.1.3"
+        val runner = "1.1.1"
+        val espresso = "3.1.1"
+    }
+
+    val sdkVersion = 28
+    val minSdkVersion = 16
+    val targetVersion = 28
+
+    val kotlinLib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Version.kotlin}"
+    val appCompat = "androidx.appcompat:appcompat:${Version.appcompat}"
+    val androidxCore = "androidx.core:core-ktx:${Version.androidx}"
+    val androidxConstraint = "androidx.constraintlayout:constraintlayout:${Version.constraint}"
+    val junit = "junit:junit:4.12"
+    val testRunner = "androidx.test:runner:${Version.runner}"
+    val espressoCore = "androidx.test.espresso:espresso-core:${Version.espresso}"
+}


### PR DESCRIPTION
## 何をしたか ( What )
- `buildSrc`モジュールを作成して`app/build.gradle`のdependenciesを置き換えました。

## 何のためにしたか ( Why )
- バージョンなど、ライブラリの一括管理をしたいため
- ~IDE補完で記述したいため~

## 懸念点
- AndroidStudio3.4で補完されない疑惑・・・
- 一括管理は出来てるので問題ない
- ドキュメント書く

## issueなどlink
https://qiita.com/TaigaNatto/items/7ec9aa0f2144559c7eaa
